### PR TITLE
fix placement bug for 4:3

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -91,8 +91,8 @@ const resetStyle = () => {
   }
 
   overlay.show();
-  width -= border_size * 2;
-  height -= border_size * 2;
+  const inner_width = width - border_size * 2;
+  const inner_height = height - border_size * 2;
   overlay.set_style(
     `background-color: transparent;
         margin-left: ${
@@ -101,8 +101,8 @@ const resetStyle = () => {
             : 0
         }px;
         border: ${border_size}px solid white;
-        width: ${width}px;
-        height: ${height}px;`
+        width: ${inner_width}px;
+        height: ${inner_height}px;`
   );
 };
 


### PR DESCRIPTION
a math error was causing fixed aspect ratio borders (4:3, 16:9 -- as opposed to full screen) to be horizontally misaligned by 1 border-width